### PR TITLE
[fix] 07/17 무한 스크롤 로직 수정, 회원가입 시 임시 프로필 등록 로직으로 수정 #111

### DIFF
--- a/app/community/hooks/usePostAccumulator.ts
+++ b/app/community/hooks/usePostAccumulator.ts
@@ -1,12 +1,8 @@
 import { Board } from "@/app/(main)/hooks/useUserProfile";
-import { useEffect } from "react";
-
-interface PostList {
-  boardList: Board[];
-}
+import { useEffect, useRef } from "react";
 
 interface UsePostAccumulatorOptions {
-  postList?: PostList;
+  postList?: Board[];
   setAllPosts: (posts: Board[] | ((prev: Board[]) => Board[])) => void;
 }
 
@@ -14,13 +10,18 @@ export const usePostAccumulator = ({
   postList,
   setAllPosts,
 }: UsePostAccumulatorOptions) => {
+  const lastPostIdsRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
-    if (postList?.boardList) {
-      setAllPosts((prev) => {
-        const ids = new Set(prev.map((p) => p.id));
-        const newUniquePosts = postList.boardList.filter((p) => !ids.has(p.id));
-        return [...prev, ...newUniquePosts];
-      });
+    if (!postList || postList.length === 0) return;
+
+    const newPosts = postList.filter(
+      (p) => !lastPostIdsRef.current.has(String(p.id)),
+    );
+
+    if (newPosts.length > 0) {
+      newPosts.forEach((p) => lastPostIdsRef.current.add(String(p.id)));
+      setAllPosts((prev) => [...prev, ...newPosts]);
     }
   }, [postList, setAllPosts]);
 };

--- a/app/community/hooks/usePostInfiniteScroll.ts
+++ b/app/community/hooks/usePostInfiniteScroll.ts
@@ -4,6 +4,7 @@ interface UsePostInfiniteScrollOptions {
   loaderRef: RefObject<HTMLElement>;
   scrollRef: RefObject<HTMLElement>;
   isLastPage?: boolean;
+  isFetching: boolean;
   onLoadMore: () => void;
   enabled?: boolean;
   page: number;
@@ -14,6 +15,7 @@ export const usePostInfiniteScroll = ({
   loaderRef,
   scrollRef,
   isLastPage,
+  isFetching,
   onLoadMore,
   enabled = true,
   page,
@@ -22,6 +24,11 @@ export const usePostInfiniteScroll = ({
   useEffect(() => {
     if (!enabled) return;
 
+    const loaderTarget = loaderRef.current;
+    const scrollTarget = scrollRef.current;
+
+    if (!loaderTarget) return;
+
     const observer = new IntersectionObserver(
       (entries) => {
         const first = entries[0];
@@ -29,27 +36,23 @@ export const usePostInfiniteScroll = ({
 
         if (page === 1 && allPostsLength === 0) return;
 
-        if (isLastPage) return;
-
         onLoadMore();
       },
-      { threshold: 1.0, root: scrollRef.current },
+      { threshold: 1.0, root: scrollTarget },
     );
 
-    const target = loaderRef.current;
-
     const timeout = setTimeout(() => {
-      if (target && !isLastPage) {
-        observer.observe(target);
+      if (loaderTarget && !isLastPage) {
+        observer.observe(loaderTarget);
       }
     }, 100);
 
     return () => {
       clearTimeout(timeout);
-      if (target) observer.unobserve(target);
+      observer.disconnect();
     };
   }, [
-    loaderRef.current,
+    loaderRef,
     scrollRef,
     isLastPage,
     onLoadMore,

--- a/app/community/hooks/usePostInfiniteScroll.ts
+++ b/app/community/hooks/usePostInfiniteScroll.ts
@@ -33,23 +33,23 @@ export const usePostInfiniteScroll = ({
 
         onLoadMore();
       },
-      { threshold: 0.5, root: scrollRef.current },
+      { threshold: 1.0, root: scrollRef.current },
     );
 
+    const target = loaderRef.current;
+
     const timeout = setTimeout(() => {
-      const current = loaderRef.current;
-      if (current && !isLastPage) {
-        observer.observe(current);
+      if (target && !isLastPage) {
+        observer.observe(target);
       }
     }, 100);
 
-    const current = loaderRef.current;
     return () => {
       clearTimeout(timeout);
-      if (current) observer.unobserve(current);
+      if (target) observer.unobserve(target);
     };
   }, [
-    loaderRef,
+    loaderRef.current,
     scrollRef,
     isLastPage,
     onLoadMore,

--- a/app/community/hooks/usePostList.ts
+++ b/app/community/hooks/usePostList.ts
@@ -1,5 +1,5 @@
 import { fetchWithAuth } from "@/app/lib/api/fetchWithAuth";
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery } from "@tanstack/react-query";
 import { BoardListType } from "../types/boardListType";
 import { useIsLoggedIn } from "@/app/hooks/useIsLoggedIn";
 
@@ -23,12 +23,16 @@ const getPostList = async (
   return postList;
 };
 
-export const usePostList = (page: number) => {
+export const usePostList = () => {
   const isLoggedIn = useIsLoggedIn();
 
-  return useQuery({
-    queryKey: ["postList", isLoggedIn, page],
-    queryFn: () => getPostList(isLoggedIn, page),
+  return useInfiniteQuery({
+    queryKey: ["postList", isLoggedIn],
+    queryFn: ({ pageParam = 1 }) => getPostList(isLoggedIn, pageParam),
+    getNextPageParam: (lastPage, allPages) => {
+      return lastPage.isLastPage ? undefined : allPages.length + 1;
+    },
+    initialPageParam: 1,
     enabled: typeof window !== "undefined",
     staleTime: 0,
   });

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -32,8 +32,10 @@ const Page = () => {
     () => getActiveFilter(pathname) || "전체",
   );
   const [showProfileModal, setShowProfileModal] = useState(false);
-  const { data: postList } = usePostList(page);
+  const { data, fetchNextPage, hasNextPage, isFetching } = usePostList();
   const { data: user } = useUserProfile(isLoggedIn);
+
+  const postList = data?.pages.flatMap((page) => page.boardList) || [];
 
   useScrollRestoration(scrollRef);
   usePostAccumulator({ postList, setAllPosts });
@@ -44,13 +46,17 @@ const Page = () => {
   const filteredPosts = useFilteredPosts(allPosts, activeFilter);
 
   const loadNextPage = useCallback(() => {
-    setPage(page + 1);
-  }, [page, setPage]);
+    if (hasNextPage && !isFetching) {
+      fetchNextPage();
+      setPage((prev) => prev + 1);
+    }
+  }, [data, hasNextPage, isFetching, setPage]);
 
   usePostInfiniteScroll({
     loaderRef,
     scrollRef,
-    isLastPage: postList?.isLastPage,
+    isLastPage: !hasNextPage,
+    isFetching,
     onLoadMore: loadNextPage,
     page,
     allPostsLength: allPosts.length,

--- a/app/community/store/useCommunityStore.ts
+++ b/app/community/store/useCommunityStore.ts
@@ -6,7 +6,7 @@ interface CommunityStore {
   setAllPosts: (posts: Board[] | ((prev: Board[]) => Board[])) => void;
   appendPosts: (posts: Board[] | ((prev: Board[]) => Board[])) => void;
   page: number;
-  setPage: (page: number) => void;
+  setPage: (page: number | ((prev: number) => number)) => void;
   reset: () => void;
 }
 
@@ -24,7 +24,10 @@ export const useCommunityStore = create<CommunityStore>((set) => ({
           : [...state.allPosts, ...posts],
     })),
   page: 1,
-  setPage: (page) => set({ page }),
+  setPage: (page: number | ((prev: number) => number)) =>
+    set((state) => ({
+      page: typeof page === "function" ? page(state.page) : page,
+    })),
   reset: () =>
     set({
       allPosts: [],

--- a/app/components/header/HeaderBackButton.tsx
+++ b/app/components/header/HeaderBackButton.tsx
@@ -22,6 +22,11 @@ const HeaderBackButton = () => {
   const handleBack = () => {
     const page = searchParams.get("page");
 
+    if (pathname === "/create/info") {
+      router.replace("/");
+      return;
+    }
+
     if (keyword) {
       const query = new URLSearchParams();
       if (page) query.set("page", page);

--- a/app/web-auth/kakao/callback/page.tsx
+++ b/app/web-auth/kakao/callback/page.tsx
@@ -52,13 +52,7 @@ const KakaoCallbackPage = () => {
 
           localStorage.removeItem("profile-form-data");
 
-          const hasProfile = await checkHasWebProfile(result.data.accessToken);
-
-          if (hasProfile) {
-            router.replace("/");
-          } else {
-            router.replace("/create/info");
-          }
+          router.replace("/");
         } else {
           const error: ErrorResponse = await res.json();
 


### PR DESCRIPTION
## 🔘Part

- [x] FE

  <br/>

## 🔎 작업 내용
- 무한 스크롤 로직 수정 (useQuery -> useInfiniteQuery)
- 회원가입 -> 프로필 등록 -> 뒤로가기 -> 프로필로 이동(임시 프로필)
  <br/>

## 이미지 첨부

<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크

- [Village #111 ]

<br/>
